### PR TITLE
Make non-empty settings look not empty

### DIFF
--- a/core/admin/ajax/settings/get-page.php
+++ b/core/admin/ajax/settings/get-page.php
@@ -8,7 +8,8 @@
 	$results = $admin->getPageOfSettings($page,$query);
 	
 	foreach ($results as $item) {
-		if (is_array($item["value"])) {
+		if (is_array($item["value"]) ||
+			(strlen(trim(strip_tags($item["value"]))) === 0)) {
 			$value = "&mdash; Click Edit To View &mdash;";
 		} else {
 			$value = BigTree::trimLength(strip_tags($item["value"]),100);


### PR DESCRIPTION
##### A small use case and a small change

I'm building a site for a client who's looking to paste in some of their system data (xml in this case). Escaping and unescaping was fairly messy.
I dodged that by following the suggestion [here](https://github.com/bigtreecms/BigTree-CMS/blob/master/core/inc/bigtree/admin.php#L919) -- hat tip for leaving that open.
Then came the slight downside: they were unhappy to see that their data appeared as non-existent when browsing the settings page, hence this pull request.

Hope it helps!  And also, would you guys be inclined to accept some larger changes implementing something similar to the 'parser' that's offered when creating module views?  