### PR TITLE
mysqli: Add more connection params to connect function

### DIFF
--- a/core/inc/bigtree/sql.php
+++ b/core/inc/bigtree/sql.php
@@ -6,21 +6,40 @@
 
 	$bigtree["sql"]["errors"] = array();
 	$bigtree["sql"]["queries"] = array();
-	
+
 	if (isset($bigtree["config"]["sql_interface"]) && $bigtree["config"]["sql_interface"] == "mysqli") {
-	
+
 		function bigtree_setup_sql_connection($read_write = "read") {
 			global $bigtree;
-			
+
+			// Initializing optional params, if they don't exist yet
+			isset($bigtree["config"]["db"]["host"]) 	|| $bigtree["config"]["db"]["host"] = null;
+			isset($bigtree["config"]["db"]["port"]) 	|| $bigtree["config"]["db"]["port"] = 3306;
+			isset($bigtree["config"]["db"]["socket"]) || $bigtree["config"]["db"]["socket"] = null;
+
 			if ($read_write == "read") {
-				$connection = new mysqli($bigtree["config"]["db"]["host"],$bigtree["config"]["db"]["user"],$bigtree["config"]["db"]["password"],$bigtree["config"]["db"]["name"]);
+				$connection = new mysqli(
+						$bigtree["config"]["db"]["host"],
+						$bigtree["config"]["db"]["user"],
+						$bigtree["config"]["db"]["password"],
+						$bigtree["config"]["db"]["name"],
+						$bigtree["config"]["db"]["port"],
+						$bigtree["config"]["db"]["socket"]
+					);
 				$connection->query("SET NAMES 'utf8'");
 				$connection->query("SET SESSION sql_mode = ''");
 				// Remove BigTree connection parameters once it is setup.
 				unset($bigtree["config"]["db"]["user"]);
 				unset($bigtree["config"]["db"]["password"]);
 			} else {
-				$connection = new mysqli($bigtree["config"]["db_write"]["host"],$bigtree["config"]["db_write"]["user"],$bigtree["config"]["db_write"]["password"],$bigtree["config"]["db_write"]["name"]);
+				$connection = new mysqli(
+						$bigtree["config"]["db_write"]["host"],
+						$bigtree["config"]["db_write"]["user"],
+						$bigtree["config"]["db_write"]["password"],
+						$bigtree["config"]["db_write"]["name"],
+						$bigtree["config"]["db_write"]["port"],
+						$bigtree["config"]["db_write"]["socket"]
+					);
 				$connection->query("SET NAMES 'utf8'");
 				$connection->query("SET SESSION sql_mode = ''");
 				// Remove BigTree connection parameters once it is setup.
@@ -29,30 +48,30 @@
 			}
 			return $connection;
 		}
-		
+
 		/*
 			Function: sqlquery
 				Equivalent to mysqli_query / mysql_query in most cases.
 				If BigTree has enabled splitting off to a separate write server this function will send all write related queries to the write server and all read queries to the read server.
 				If BigTree has not enabled a separate write server the type parameter does not exist.
-			
+
 			Parameters:
 				query - A query string.
 				connection - An optional MySQL connection (normally this is chosen automatically)
 				type - Chosen automatically if a connection isn't passed. "read" or "write" to specify which server to use.
-				
+
 			Returns:
 				A MySQL query resource.
 		*/
-		
+
 		if (isset($bigtree["config"]["db_write"]) && $bigtree["config"]["db_write"]["host"]) {
 			function sqlquery($query,$connection = false,$type = "read") {
 				global $bigtree;
-				
+
 				if ($bigtree["config"]["debug"]) {
 					$bigtree["sql"]["queries"][] = $query;
 				}
-				
+
 				if (!$connection) {
 					$commands = explode(" ",$query);
 					$fc = strtolower($commands[0]);
@@ -64,11 +83,11 @@
 						$type = "read";
 					}
 				}
-				
+
 				if ($connection === "disconnected") {
 					$connection = bigtree_setup_sql_connection($type);
-				}	
-				
+				}
+
 				$q = $connection->query($query);
 				$e = $connection->error;
 				if ($e) {
@@ -76,25 +95,25 @@
 					array_push($bigtree["sql"]["errors"],$sqlerror);
 					return false;
 				}
-				
+
 				return $q;
 			}
 		} else {
 			function sqlquery($query,$connection = false) {
 				global $bigtree;
-				
+
 				if ($bigtree["config"]["debug"]) {
 					$bigtree["sql"]["queries"][] = $query;
 				}
-				
+
 				if (!$connection) {
 					$connection = &$bigtree["mysql_read_connection"];
 				}
-				
+
 				if ($connection === "disconnected") {
 					$connection = bigtree_setup_sql_connection();
 				}
-				
+
 				$q = $connection->query($query);
 				$e = $connection->error;
 				if ($e) {
@@ -102,23 +121,23 @@
 					array_push($bigtree["sql"]["errors"],$sqlerror);
 					return false;
 				}
-				
+
 				return $q;
 			}
 		}
-		
+
 		/*
 			Function: sqlfetch
 				Equivalent to mysqli_fetch_assoc / mysql_fetch_assoc.
 				Throws an exception if it is called on an invalid query resource which includes the most recent MySQL errors.
-			
+
 			Parameters:
 				query - The mysql query resource (returned via sqlquery or mysql_query or mysql_db_query)
-			
+
 			Returns:
 				A row from the query in array format with key/value pairs.
 		*/
-		
+
 		function sqlfetch($query) {
 			global $bigtree;
 			// If the query is boolean, it's probably a "false" from a failed sql query.
@@ -129,21 +148,21 @@
 				return $query->fetch_assoc();
 			}
 		}
-		
+
 		/*
 			Function: sqlrows
 				Equivalent to mysqli_num_rows / mysql_num_rows.
 		*/
-		
+
 		function sqlrows($result) {
 			return $result->num_rows;
 		}
-		
+
 		/*
 			Function: sqlid
 				Equivalent to mysqli_insert_id / mysql_insert_id.
 		*/
-		
+
 		function sqlid() {
 			global $bigtree;
 			if ($bigtree["mysql_write_connection"] !== "disconnected") {
@@ -152,12 +171,12 @@
 				return $bigtree["mysql_read_connection"]->insert_id;
 			}
 		}
-		
+
 		/*
 			Function: sqlescape
 				Equivalent to mysqli_real_escape_string / mysql_real_escape_string
 		*/
-		
+
 		function sqlescape($string) {
 			global $bigtree;
 			if ($bigtree["mysql_read_connection"] === "disconnected") {
@@ -173,7 +192,7 @@
 	} else {
 		function bigtree_setup_sql_connection($read_write = "read") {
 			global $bigtree;
-			
+
 			if ($read_write == "read") {
 				$connection = mysql_connect($bigtree["config"]["db"]["host"],$bigtree["config"]["db"]["user"],$bigtree["config"]["db"]["password"]);
 				mysql_select_db($bigtree["config"]["db"]["name"],$connection);
@@ -193,15 +212,15 @@
 			}
 			return $connection;
 		}
-		
+
 		if (isset($bigtree["config"]["db_write"]) && $bigtree["config"]["db_write"]["host"]) {
 			function sqlquery($query,$connection = false,$type = "read") {
 				global $bigtree;
-				
+
 				if ($bigtree["config"]["debug"]) {
 					$bigtree["sql"]["queries"][] = $query;
 				}
-				
+
 				if (!$connection) {
 					$commands = explode(" ",$query);
 					$fc = strtolower($commands[0]);
@@ -213,11 +232,11 @@
 						$type = "read";
 					}
 				}
-				
+
 				if ($connection === "disconnected") {
 					$connection = bigtree_setup_sql_connection($type);
-				}	
-				
+				}
+
 				$q = mysql_query($query,$connection);
 				$e = mysql_error();
 				if ($e) {
@@ -225,25 +244,25 @@
 					array_push($bigtree["sql"]["errors"],$sqlerror);
 					return false;
 				}
-				
+
 				return $q;
 			}
 		} else {
 			function sqlquery($query,$connection = false) {
 				global $bigtree;
-				
+
 				if ($bigtree["config"]["debug"]) {
 					$bigtree["sql"]["queries"][] = $query;
 				}
-				
+
 				if (!$connection) {
 					$connection = &$bigtree["mysql_read_connection"];
 				}
-				
+
 				if ($connection === "disconnected") {
 					$connection = bigtree_setup_sql_connection();
 				}
-				
+
 				$q = mysql_query($query,$connection);
 				$e = mysql_error();
 				if ($e) {
@@ -251,14 +270,14 @@
 					array_push($bigtree["sql"]["errors"],$sqlerror);
 					return false;
 				}
-				
+
 				return $q;
 			}
 		}
-		
+
 		function sqlfetch($query) {
 			global $bigtree;
-			
+
 			// If the query is boolean, it's probably a "false" from a failed sql query.
 			if (is_bool($query)) {
 				trigger_error("sqlfetch called on invalid query resource. The most likely cause is an invalid sqlquery call. Last error returned was: ".$bigtree["sql"]["errors"][count($bigtree["sql"]["errors"])-1]);
@@ -267,21 +286,21 @@
 				return mysql_fetch_assoc($query);
 			}
 		}
-		
+
 		function sqlrows($result) {
 			return mysql_num_rows($result);
 		}
-		
+
 		function sqlid() {
 			global $bigtree;
-			
+
 			if ($bigtree["mysql_write_connection"] !== "disconnected") {
 				return mysql_insert_id($bigtree["mysql_write_connection"]);
 			} else {
-				return mysql_insert_id($bigtree["mysql_read_connection"]);			
+				return mysql_insert_id($bigtree["mysql_read_connection"]);
 			}
 		}
-		
+
 		function sqlescape($string) {
 			global $bigtree;
 			if ($bigtree["mysql_read_connection"] === "disconnected") {


### PR DESCRIPTION
In order to connect to a MySQL database via socket, I added some more params that are passed to `new mysqli(...)`. For example this is needed

* if you want to connect to a Google Cloud SQL instance (see: https://cloud.google.com/appengine/docs/php/cloud-sql/#PHP_Connect_to_your_database) or
* if you want to connect to a MySQL server that uses a non-standard port.

At the moment, these additional parameters are not configurable via the installer. You can set them manually in your `custom/environment.php`. If the params are missing, they will be initialized, so no warnings are thrown.

And sorry for removing so much whitespace :relaxed: 