### PR TITLE
Prevent current date from always being selected and allow user to remove previously saved date

### DIFF
--- a/core/admin/css/main.css
+++ b/core/admin/css/main.css
@@ -1548,6 +1548,8 @@
 	.ui-datepicker .ui-datepicker-buttonpane { background-image: none; border-bottom: 0; border-left: 0; border-right: 0; margin: .7em 0 0 0; padding: 0 .2em; }
 	.ui-datepicker .ui-datepicker-buttonpane button { cursor: pointer; float: right; margin: .5em .2em .4em; overflow: visible; padding: .2em .6em .3em .6em; width: auto; }
 	.ui-datepicker .ui-datepicker-buttonpane button.ui-datepicker-current { float: left; }
+	
+	.date_picker_clear { display: inline-block; float: right; margin-right: 35%; padding: 7px 8px; background: #C0362F; color: #FFF; cursor: pointer; }
 
 	.ui-datepicker-prev:before { content: "\21E6"; cursor: pointer; font-size: 16px; }
 	.ui-datepicker-next:before { content: "\21E8"; cursor: pointer; font-size: 16px; }

--- a/core/admin/form-field-types/draw/date.php
+++ b/core/admin/form-field-types/draw/date.php
@@ -9,12 +9,12 @@
 	
 	// We draw the picker inline for callouts
 	if (defined("BIGTREE_CALLOUT_RESOURCES")) {
-		if (!$field["value"]) {
+		if (!isset($field["value"])) {
 			$field["value"] = date($bigtree["config"]["date_format"]);
 		}
 ?>
 <input type="hidden" name="<?=$field["key"]?>" value="<?=$field["value"]?>" />
-<div class="date_picker_inline" data-date="<?=$field["value"]?>"></div>
+<div class="date_picker_inline" data-date="<?=$field["value"]?>"><div class="date_picker_clear">Clear Date</div></div>
 <?
 	} else {
 ?>

--- a/core/admin/form-field-types/draw/datetime.php
+++ b/core/admin/form-field-types/draw/datetime.php
@@ -20,7 +20,7 @@
 		}
 ?>
 <input type="hidden" name="<?=$field["key"]?>" value="<?=$field["value"]?>" />
-<div class="date_time_picker_inline" data-date="<?=$field["value"]?>" data-hour="<?=$hour?>" data-minute="<?=$minute?>"></div>
+<div class="date_time_picker_inline" data-date="<?=$field["value"]?>" data-hour="<?=$hour?>" data-minute="<?=$minute?>"><div class="date_picker_clear">Clear Date</div></div>
 <?
 	} else {
 ?>

--- a/core/admin/js/main.js
+++ b/core/admin/js/main.js
@@ -3091,6 +3091,9 @@ var BigTree = {
 			var field = $(this).attr("href").substr(1);
 			BigTreeFileManager.formOpen("image",field,options);
 			return false;
+		}).on("click",".date_picker_clear",function() {
+			$(this).parent().siblings('input').val('');
+			$(this).siblings('.ui-datepicker').find('.ui-state-default.ui-state-active').removeClass('ui-state-active');
 		});
 		
 		// Pickers
@@ -3103,6 +3106,11 @@ var BigTree = {
 			$(this).datepicker({ dateFormat: BigTree.dateFormat, defaultDate: $(this).attr("data-date"), onSelect: function(dateText) {
 				$(this).prev("input").val(dateText);
 			}});
+			
+			if(typeof $(this).attr("data-date") == 'undefined' || $(this).attr("data-date") == '')
+			{
+				$(this).find('.ui-state-default.ui-state-highlight.ui-state-active').removeClass('ui-state-active');
+			}
 		});
 		$(".time_picker_inline").each(function() {
 			var hour = $(this).attr("data-hour");
@@ -3115,6 +3123,11 @@ var BigTree = {
 			$(this).datetimepicker({ dateFormat: BigTree.dateFormat, timeFormat: "hh:mm tt", defaultDate: $(this).attr("data-date"), ampm: true, hour: $(this).attr("data-hour"), minute: $(this).attr("data-minute"), hourGrid: 6, minuteGrid: 10, onSelect: function(dateText) {
 				$(this).prev("input").val(dateText);
 			}});
+			
+			if(typeof $(this).attr("data-date") == 'undefined' || $(this).attr("data-date") == '')
+			{
+				$(this).find('.ui-state-default.ui-state-highlight.ui-state-active').removeClass('ui-state-active');
+			}
 		});
 	},
 

--- a/core/inc/bigtree/auto-modules.php
+++ b/core/inc/bigtree/auto-modules.php
@@ -1747,7 +1747,7 @@
 				// Requires url and it isn't
 				} elseif (in_array("link",$parts) && !filter_var($data,FILTER_VALIDATE_URL)) {
 					return false;
-				} elseif (in_array("required",$parts) && !$data) {
+				} elseif (in_array("required",$parts) && $data === false) {
 					return false;
 				// It exists and validates as numeric, an email, or URL
 				} else {

--- a/core/router.php
+++ b/core/router.php
@@ -447,6 +447,11 @@
 		'),$bigtree["content"]);
 		// Replace script and image tags.
 		$bigtree["content"] = str_replace('src="http://','src="https://',$bigtree["content"]);
+		//Replace inline background images
+		$patterns = array("/url\('http:\/\//", '/url\("http:\/\//', '/url\(http:\/\//');
+		$replacements = array("url('https://", 'url("https://', "url(https://");
+		$bigtree["content"] = preg_replace($patterns, $replacements, $bigtree["content"]);
+		unset($patterns, $replacements);
 	}
 	
 	// Load the BigTree toolbar if you're logged in to the admin via cookies but not yet via session.


### PR DESCRIPTION
On the date and datetime fields, when they are drawn inline in callouts/matrices the default date is already selected and cannot be unselected. I fixed a bug in the draw file to stop this. I also made changes so that the current date would not appear selected when the value is empty or non-existent. This is a documented issue with datepicker (http://bugs.jqueryui.com/ticket/8159) so I worked around it by removing the active class only when the value was empty. Lastly, I added a "Clear Date" button so that if a user entered and saved a date, they would have the ability to come back in and remove it later.