### PR TITLE
Add checkbox values to title/subtitle of matrix fields

### DIFF
--- a/core/admin/js/main.js
+++ b/core/admin/js/main.js
@@ -2984,7 +2984,7 @@ var BigTreeMatrix = function(settings) {
 			Title = Subtitle = "";
 			LastDialog.find(".matrix_title_field").each(function(index,el) {
 				if (!Title || !Subtitle) {
-					var item = $(el).find("input[type=text],input[type=email],input[type=url],textarea,select").not("[type=file]");
+					var item = $(el).find("input[type=checkbox],input[type=text],input[type=email],input[type=url],textarea,select").not("[type=file]");
 					if (item.length) {
 						// Going to check for multi-part inputs like names, address, phone
 						var parent = item.parent();
@@ -3003,6 +3003,10 @@ var BigTreeMatrix = function(settings) {
 							var value = $.trim(item.find("option:selected").text());
 						} else {
 							var value = $.trim(item.val());
+						}
+						// Reset value if item is an unchecked checkbox
+						if (item.attr('type') == 'checkbox' && !item.is(":checked")){
+							value = false;
 						}
 						if (value) {
 							if (!Title) {


### PR DESCRIPTION
Allow for the value of a checked checkbox to be used as the internal title or subtitle. Use case: A matrix where each item has a checkbox that marks it as "active." If setup correctly, the user could easily see which items were "active" by having the checkbox be the subtitle of each item.