### PR TITLE
False positives on embedded form submissions

### DIFF
--- a/core/admin/ajax/auto-modules/embeddable-form/process.php
+++ b/core/admin/ajax/auto-modules/embeddable-form/process.php
@@ -26,7 +26,7 @@
 	}
 
 	// Stop Robots - See if it matches the passed hash and that _bigtree_email wasn't filled out
-	if ($_POST["_bigtree_hashcash"] != md5($cleaned_string) || $_POST["_bigtree_email"]) {
+	if (trim($_POST["_bigtree_hashcash"]) != trim(md5($cleaned_string)) || $_POST["_bigtree_email"]) {
 		$_SESSION["bigtree_admin"]["post_hash_failed"] = true;
 		BigTree::redirect($_SERVER["HTTP_REFERER"]);
 	}


### PR DESCRIPTION
We have had some submissions return false positives on this if statement which causes it to fail. It appears that this results from an extra white space at the end of the $_POST["_bigtree_hashcash"] so trimming both variables appears to have fixed it.