### PR TITLE
try to fix issue with bigtree front-end-editor constant

### DIFF
--- a/core/admin/ajax/callouts/add.php
+++ b/core/admin/ajax/callouts/add.php
@@ -47,7 +47,7 @@
 				count: <?=$bigtree["callout_count"]?>,
 				key: "<?=$bigtree["callout_key"]?>",
 				tab_depth: <?=intval($_POST["tab_depth"])?>,
-				front_end_editor: <?=defined("BIGTREE_FRONT_END_EDITOR")?>
+				front_end_editor: <?=(defined("BIGTREE_FRONT_END_EDITOR") ? "true" : "false")?>
 			},BigTree.formHooks).scrollTop(0);
 		});
 	})();

--- a/core/admin/ajax/callouts/edit.php
+++ b/core/admin/ajax/callouts/edit.php
@@ -36,14 +36,14 @@
 		Select.change(function(event,data) {
 			// TinyMCE tooltips and menus sometimes get stuck
 			$(".mce-tooltip, .mce-menu").remove();
-	
+
 			Fields.load("<?=ADMIN_ROOT?>ajax/callouts/resources/", {
 				count: <?=$bigtree["callout_count"]?>,
 				key: "<?=$bigtree["callout_key"]?>",
 				resources: "<?=htmlspecialchars($_POST["data"])?>",
 				type: data.value,
 				tab_depth: <?=intval($_POST["tab_depth"])?>,
-				front_end_editor: <?=defined("BIGTREE_FRONT_END_EDITOR")?>
+				front_end_editor: <?=(defined("BIGTREE_FRONT_END_EDITOR") ? "true" : "false")?>
 			}, BigTreeCustomControls).scrollTop(0);
 		});
 	})();


### PR DESCRIPTION
Hey Tim, on Friday you fixed an error where the javascript was looking for a true/false when the user is or isn't editing from the front-end. It looks like you missed editing the callout add and edit files. 
this tiny change using your new pattern from elsewhere seems to fix things on my end.