### PR TITLE
Cron does not work. Config is not found

### DIFF
--- a/core/cron.php
+++ b/core/cron.php
@@ -1,5 +1,6 @@
 <?php
-	$server_root = str_replace("core/cron.php","",strtr(__FILE__, "\\", "/"));
+	// Store the BigTree root path.
+	$server_root = realpath('') . '/';
 	include $server_root."custom/environment.php";
 	include $server_root."custom/settings.php";
 	include $server_root."core/bootstrap.php";


### PR DESCRIPTION
Fix the issue with including config files in the cron.php.
see issue details in https://github.com/bigtreecms/BigTree-CMS/issues/361

@timbuckingham this fix helps on our BigTree environment and should work just fine on any other. Would be great to test it. 

Thanks. 