### PR TITLE
Fix Deprecated Implode Syntax in LESS compiler Dependency

### DIFF
--- a/vendor/oyejorge/less.php/lib/Less/SourceMap/Generator.php
+++ b/vendor/oyejorge/less.php/lib/Less/SourceMap/Generator.php
@@ -334,7 +334,7 @@ class Less_SourceMap_Generator extends Less_Configurable {
 			$groupedMapEncoded[] = implode(',', $lineMapEncoded) . ';';
 		}
 
-		return rtrim(implode($groupedMapEncoded), ';');
+		return rtrim(implode(';', $groupedMapEncoded));
 	}
 
 	/**


### PR DESCRIPTION
In PHP 7.4+ you have to use  implode(string $separator, array $array), not the deprecated legacy form implode(array $array, string $separator)