### PR TITLE
Don't use curly brace syntax for arrays

### DIFF
--- a/core/inc/bigtree/utils.php
+++ b/core/inc/bigtree/utils.php
@@ -1716,7 +1716,7 @@
 			$str = '';
 			$seeds_count = strlen($seeds);
 			for ($i = 0; $length > $i; $i++) {
-				$str .= $seeds{mt_rand(0, $seeds_count - 1)};
+				$str .= $seeds[mt_rand(0, $seeds_count - 1)];
 			}
 			
 			return $str;


### PR DESCRIPTION
Curly brace syntax for arrays and strings is deprecated starting PHP 7.4
https://wiki.php.net/rfc/deprecate_curly_braces_array_access