### PR TITLE
Update launch.php

### DIFF
--- a/core/launch.php
+++ b/core/launch.php
@@ -34,7 +34,7 @@
 	}
 
 	// Prevent path manipulations
-	if (strpos($_GET["bigtree_htaccess_url"], "..\\") !== false) {
+	if (isset($_GET["bigtree_htaccess_url"]) && strpos($_GET["bigtree_htaccess_url"], "..\\") !== false) {
 		die();
 	}
 	


### PR DESCRIPTION
PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in D:\HTTPS-SERVER-D-VHOSTS\testi\BigTree-CMS\core\launch.php on line 37

It is necessary to check that array value $_GET["bigtree_htaccess_url"] exists in $_GET before using strpos()